### PR TITLE
FIX: use `didInsertElement()` instead of `init()`

### DIFF
--- a/javascripts/discourse/components/big-carousel.js
+++ b/javascripts/discourse/components/big-carousel.js
@@ -79,8 +79,12 @@ export default Component.extend({
     return currentRouteName === "discovery.categories";
   },
 
-  init() {
+  didInsertElement() {
     this._super(...arguments);
     this.appEvents.on("page:changed", this, "ensureSlider");
+  },
+
+  willDestroyElement() {
+    this.appEvents.off("page:changed", this, "ensureSlider");
   },
 });


### PR DESCRIPTION
This fixes an issue where the script was firing before content had loaded when returning to the homepage from elsewhere. 